### PR TITLE
Fix repository empty link

### DIFF
--- a/content/blog/monitoring-debugging-lambda-app-without-knowing-of-aws.md
+++ b/content/blog/monitoring-debugging-lambda-app-without-knowing-of-aws.md
@@ -50,7 +50,7 @@ The answer is self explanatory (just kidding), well with the [__Serverless Frame
 
 ![The Best Sushi App working](/images/blog/22-03-2018/app-working.gif)
 
-The complete app source code is available in this [repository]() and is branched in the same way that will be explain it here...
+The complete app source code is available in this [repository](https://github.com/imjaroiswebdev/aws-lambda-best-sushi-app) and is branched in the same way that will be explain it here...
 
 * master (__Complete app__)
 1. adding-orders


### PR DESCRIPTION
The repository link in the article was empty.
![image](https://user-images.githubusercontent.com/24704624/37826789-a410635c-2e73-11e8-98c5-9a48724335ef.png)
