### PR TITLE
Remove likely focus-stolen typo ('git st') in main docs page

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -47,7 +47,6 @@ These metrics support not only function health analysis, but also resource and c
 Dashbird monitors cloud components in serverless applications and cross-reference against well-architected best practices. Services monitored by Dashbird Insights include SQS queues, ECS containers, DynamoDB tables, API Gateways.
 
 Insights are automatically generated when:
-git st
 * Your infrastructure is likely to fail
 * Our system identifies opportunities for improvement
 


### PR DESCRIPTION
It appears a developer was likely attempting to perform a `git status`, but the focus was present in the editor window rather than the terminal.

Just threw me off when reading through the docs.